### PR TITLE
Add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,13 @@
+{
+  "name": "Shigi blog (Gatsby)",
+  "install": "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm install v18.17.1 >/dev/null && export PATH=\"$HOME/.nvm/versions/node/v18.17.1/bin:$PATH\" && corepack enable && corepack prepare yarn@1.22.22 --activate && yarn install --frozen-lockfile",
+  "terminals": [
+    {
+      "name": "gatsby-develop",
+      "command": "export PATH=\"$HOME/.nvm/versions/node/v18.17.1/bin:$PATH\" && cd /workspace && GATSBY_TELEMETRY_DISABLED=1 yarn develop -H 0.0.0.0 -p 8000"
+    }
+  ],
+  "ports": [
+    8000
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

このリポジトリ（Gatsby v3 製の個人ブログ「Shigi blog」）を Cursor Cloud Agent 上でそのまま開発できるように、`.cursor/environment.json` を追加します。

## 背景 / 設計

- リポジトリは Node `v18.17.1` を固定（`.nvmrc` / `.node-version`）しており、Gatsby v3 + React 17 に適合します。デフォルトの Cloud Agent 基盤イメージは Node 22 系のため、`install` で nvm を用いて Node 18 を用意します。
- パッケージマネージャは yarn 1.22.22（`yarn.lock`）。corepack で固定バージョンを有効化します。
- 追加の system パッケージや Dockerfile は不要で、デフォルト基盤イメージ + `install` のみで完結する自己完結型の構成です。

## 変更内容

`.cursor/environment.json`:
- `install`: nvm で Node 18.17.1 を導入 → PATH を通す → corepack で yarn 1.22.22 を有効化 → `yarn install --frozen-lockfile`（冪等）。
- `terminals`: `gatsby develop`（`-H 0.0.0.0 -p 8000`）を常駐させ、開発サーバーのログ・再起動を可視化。
- `ports`: 8000 を公開。

## 検証

| チェック | 結果 |
| --- | --- |
| `yarn install --frozen-lockfile` | 成功（冪等性: 2 回目は `Already up-to-date`） |
| `gatsby build`（本番ビルド） | 成功（50 ページ生成、約 26 秒） |
| `gatsby develop` 開発サーバー | `/`, `/blog`, `/about`, 記事ページすべて HTTP 200 |
| ブラウザでの E2E 表示 | ホーム / ブログ一覧 / 記事 / About すべて正常レンダリング |
| Environment build（ゼロから） | `SUCCEEDED`（デフォルトイメージ上で Node 18 取得 → `yarn install` 成功） |
| Fresh Cloud Agent（ビルドから起動） | node v18.17.1 / yarn 1.22.22、`node_modules` 1209 件、`/` `/blog` `/about` すべて 200 |

### ウォークスルー動画

[shigi_blog_gatsby_develop_walkthrough.mp4](https://cursor.com/agents/bc-be72e470-7856-4402-91a9-5e645dae4bec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshigi_blog_gatsby_develop_walkthrough.mp4)

### スクリーンショット

[Home page](https://cursor.com/agents/bc-be72e470-7856-4402-91a9-5e645dae4bec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshigi_blog_home.webp)
[Blog post](https://cursor.com/agents/bc-be72e470-7856-4402-91a9-5e645dae4bec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshigi_blog_post.webp)
[About page](https://cursor.com/agents/bc-be72e470-7856-4402-91a9-5e645dae4bec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshigi_blog_about.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be72e470-7856-4402-91a9-5e645dae4bec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be72e470-7856-4402-91a9-5e645dae4bec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

