### PR TITLE
タグ・WeeklyMemo 画像・sitemap

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,9 +1,22 @@
 import mdx from "@astrojs/mdx";
+import sitemap from "@astrojs/sitemap";
 import { defineConfig } from "astro/config";
+import { isCanonicalSitemapUrl } from "./src/lib/sitemap";
 
 export default defineConfig({
   site: "https://shigi-blog.netlify.app",
-  integrations: [mdx()],
+  integrations: [
+    mdx(),
+    sitemap({
+      filter: isCanonicalSitemapUrl,
+      namespaces: {
+        news: false,
+        xhtml: false,
+        image: false,
+        video: false,
+      },
+    }),
+  ],
   trailingSlash: "never",
   markdown: {
     shikiConfig: {

--- a/content/posts/20211101.md
+++ b/content/posts/20211101.md
@@ -32,7 +32,7 @@ banner: ./book_nikkichou_diary.png
 
 ###  What I should write comment to some case
 
-<img src="./assets/1101WeeklyMemo_img/image-20211101173957526.png" alt="image-20211101173957526" style="zoom:75%;" />
+![image-20211101173957526](./assets/1101WeeklyMemo_img/image-20211101173957526.png)
 
 > コードには How
 >
@@ -48,7 +48,7 @@ banner: ./book_nikkichou_diary.png
 
 というか今思ったがコメントにおいても**最初に規約として何を書くか定めておいたほうがぶれない**のではないか！？
 
-<img src="./assets/1101WeeklyMemo_img/image-20211101175255012.png" alt="image-20211101175255012" style="zoom:75%;" />
+![image-20211101175255012](./assets/1101WeeklyMemo_img/image-20211101175255012.png)
 
 ### Summary, and in my opnion
 
@@ -133,7 +133,7 @@ pythonの\'''code\'''と似てる
 </div>
 ```
 
-<img src="./assets/1101WeeklyMemo_img/image-20211104154826909.png" alt="image-20211104154826909" style="zoom:67%;" />
+![image-20211104154826909](./assets/1101WeeklyMemo_img/image-20211104154826909.png)
 
 お前は一体何を言っているんだ
 
@@ -153,7 +153,7 @@ pythonの\'''code\'''と似てる
 
 うちの会社のトイレの水道は、水とお湯のレバーがそれぞれ3時と9時の方向を向いていて手前に90度回転させ6時の方向にすれば水やお湯が出る仕組みになっている。
 
-<img src="./assets/1101WeeklyMemo_img/image-20211105193055219.jpeg" alt="image-20211105193055219" style="zoom:33%;" />
+![image-20211105193055219](./assets/1101WeeklyMemo_img/image-20211105193055219.jpeg)
 
 従来であれば水の蛇口は3時の方向から6時の方向に90度回転させれば水が開くようになっていたが、工事された結果**レバーが既に6時の方向を向いていて、3時の方向に90度回転させることで水が開くようになっていた**。人と話しながらいつもどおり水を出したんだけど、水を出して3時の方向になっていることでヤバい違和感に気づいた。
 
@@ -173,7 +173,7 @@ pythonの\'''code\'''と似てる
 
 ### ドナルド・ノーマンのアレ
 
-<img src="./assets/1101WeeklyMemo_img/image-20211105193055218.png" alt="image-20211105193055218" style="zoom:50%;" />
+![image-20211105193055218](./assets/1101WeeklyMemo_img/image-20211105193055218.png)
 
 これでいうとアフォーダンス自体はレバーなのに実際の挙動は蛇口なので脳がバグるのである
 

--- a/content/posts/20211122.md
+++ b/content/posts/20211122.md
@@ -24,7 +24,7 @@ banner: ./book_nikkichou_diary.png
 
 ### console.table
 
-<img src="./assets/1122WeeklyMemo_img/image-20211122103725789.png" alt="image-20211122103725789" style="zoom:40%;" />
+![image-20211122103725789](./assets/1122WeeklyMemo_img/image-20211122103725789.png)
 
 APIから返ってきたresponseとか見るのにめっちゃいいじゃん…早めに知りたかった…
 
@@ -32,7 +32,7 @@ APIから返ってきたresponseとか見るのにめっちゃいいじゃん…
 
 ### Grounping log messages
 
-<img src="./assets/1122WeeklyMemo_img/image-20211122163053757.png" alt="image-20211122163123832" style="zoom:40%;" />
+![image-20211122163123832](./assets/1122WeeklyMemo_img/image-20211122163053757.png)
 
 便利そうではあるんだけど、ここまで書くかな…？といった感じ
 
@@ -40,7 +40,7 @@ APIから返ってきたresponseとか見るのにめっちゃいいじゃん…
 
 ### Info, Warn, and Error log levels
 
-<img src="./assets/1122WeeklyMemo_img/image-20211122163300438.png" alt="image-20211122163300438" style="zoom:40%;" />
+![image-20211122163300438](./assets/1122WeeklyMemo_img/image-20211122163300438.png)
 
 これ結構良さそう。APIぶっ叩いて返ってくるときのエラーメッセージとかconsole.errorで表示すれば良さそう。
 

--- a/content/posts/20211213.md
+++ b/content/posts/20211213.md
@@ -16,7 +16,7 @@ banner: ./book_nikkichou_diary.png
 
 ## `scrollbar-gutter: stable`
 
-<img src="./assets/1213WeeklyMemo_img/image-20211216103259147.png" alt="image-20211216103259147" style="zoom:67%;" />
+![image-20211216103259147](./assets/1213WeeklyMemo_img/image-20211216103259147.png)
 
 たしかにこういう状況わりとあるな
 

--- a/content/posts/20211227.md
+++ b/content/posts/20211227.md
@@ -69,7 +69,7 @@ overridesを使うときは使った後すぐ無効化するか、もともと�
 
 ## What's Web Asembly?
 
-<img src="./assets/1227WeeklyMemo_img/image-20211227172307943.png" alt="image-20211227172307943" style="zoom:30%;" />
+![image-20211227172307943](./assets/1227WeeklyMemo_img/image-20211227172307943.png)
 
 ロゴがかっこいい、グラデーションを使っているあたりかなりモダンな雰囲気が…。
 

--- a/content/posts/20220117.md
+++ b/content/posts/20220117.md
@@ -144,11 +144,11 @@ banner: ./book_nikkichou_diary.png
 
 thatが無茶苦茶消えるのはこいつのせいなのか
 
-<img src="assets/0117WeeklyMemo_img/image-20220117124853462.png" alt="image-20220117124853462" style="zoom:50%;" />
+![image-20220117124853462](./assets/0117WeeklyMemo_img/image-20220117124853462.png)
 
-<img src="assets/0117WeeklyMemo_img/image-20220117124917607.png" alt="image-20220117124917607" style="zoom:50%;" />
+![image-20220117124917607](./assets/0117WeeklyMemo_img/image-20220117124917607.png)
 
-<img src="assets/0117WeeklyMemo_img/image-20220117124929802.png" alt="image-20220117124929802" style="zoom:50%;" />
+![image-20220117124929802](./assets/0117WeeklyMemo_img/image-20220117124929802.png)
 
 ## Other
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "shigi-blog",
       "dependencies": {
         "@astrojs/mdx": "^7.0.8",
+        "@astrojs/sitemap": "^3.7.3",
         "astro": "^7.2.8"
       },
       "devDependencies": {
@@ -287,6 +288,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -2279,6 +2291,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2348,6 +2378,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5778,6 +5814,25 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
@@ -5817,6 +5872,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -5982,6 +6043,12 @@
       "engines": {
         "node": ">=22.19.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^7.0.8",
+    "@astrojs/sitemap": "^3.7.3",
     "astro": "^7.2.8"
   },
   "devDependencies": {

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,7 @@
+# Old Gatsby sitemap path
+/sitemap/sitemap-index.xml /sitemap-index.xml 301
+/sitemap/sitemap-0.xml /sitemap-0.xml 301
+
 # Old Gatsby URLs -> /YYYY-MM-DD-NN
 /0103-weekly-memo /2022-01-03-01 301
 /0110-weekly-memo /2022-01-10-01 301

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -1,5 +1,6 @@
 ---
 import type { Post } from "../lib/permalinks";
+import PostTags from "./PostTags.astro";
 
 type Props = {
   posts: Post[];
@@ -15,9 +16,7 @@ const { posts } = Astro.props;
         <a href={post.href}>{post.entry.data.title}</a>
         <div class="post-meta">
           <time datetime={post.dateStamp}>{post.dateStamp}</time>
-          {post.entry.data.tags.length > 0 && (
-            <span>{post.entry.data.tags.join(", ")}</span>
-          )}
+          <PostTags tags={post.entry.data.tags} />
         </div>
       </li>
     ))

--- a/src/components/PostTags.astro
+++ b/src/components/PostTags.astro
@@ -1,0 +1,19 @@
+---
+import { tagHref } from "../lib/tags";
+
+type Props = {
+  tags: string[];
+};
+
+const { tags } = Astro.props;
+---
+
+{
+  tags.length > 0 && (
+    <span class="post-tags">
+      {tags.map((tag) => (
+        <a href={tagHref(tag)}>{tag}</a>
+      ))}
+    </span>
+  )
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,6 +19,7 @@ const currentPath = Astro.url.pathname.replace(/\/$/, "") || "/";
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="sitemap" href="/sitemap-index.xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -38,6 +38,13 @@ const currentPath = Astro.url.pathname.replace(/\/$/, "") || "/";
             >Blog</a
           >
           <a
+            href="/tags"
+            aria-current={currentPath === "/tags" ||
+              currentPath.startsWith("/tags/")
+              ? "page"
+              : undefined}>Tags</a
+          >
+          <a
             href="/about"
             aria-current={currentPath === "/about" ? "page" : undefined}
             >About</a

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -1,0 +1,22 @@
+/**
+ * sitemap には正規 URL だけを載せる。
+ * 旧 Gatsby スラッグの 301 用ページを入れると、検索結果が古いパスに戻る。
+ */
+export function isCanonicalSitemapUrl(page: string): boolean {
+  const path = new URL(page).pathname.replace(/\/$/, "") || "/";
+
+  if (
+    path === "/" ||
+    path === "/blog" ||
+    path === "/about" ||
+    path === "/tags"
+  ) {
+    return true;
+  }
+
+  if (path.startsWith("/tags/")) {
+    return true;
+  }
+
+  return /^\/\d{4}-\d{2}-\d{2}-\d{2}$/.test(path);
+}

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,47 @@
+import { getPostsNewestFirst, type Post } from "./permalinks";
+
+/** Gatsby テーマが作っていた URL と揃える。 */
+const TAG_SLUG_BY_NAME: Record<string, string> = {
+  WeeklyMemo: "weekly-memo",
+};
+
+export function tagSlug(name: string): string {
+  return TAG_SLUG_BY_NAME[name] ?? name;
+}
+
+export function tagHref(name: string): string {
+  return `/tags/${tagSlug(name)}`;
+}
+
+export type TagGroup = {
+  name: string;
+  slug: string;
+  href: string;
+  posts: Post[];
+};
+
+export async function getTagGroups(): Promise<TagGroup[]> {
+  const posts = await getPostsNewestFirst();
+  const groups = new Map<string, TagGroup>();
+
+  for (const post of posts) {
+    for (const name of post.entry.data.tags) {
+      const current = groups.get(name);
+      if (current) {
+        current.posts.push(post);
+        continue;
+      }
+
+      groups.set(name, {
+        name,
+        slug: tagSlug(name),
+        href: tagHref(name),
+        posts: [post],
+      });
+    }
+  }
+
+  return [...groups.values()].sort((a, b) =>
+    a.name.localeCompare(b.name, "ja"),
+  );
+}

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import { render } from "astro:content";
+import PostTags from "../components/PostTags.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getPosts, type Post } from "../lib/permalinks";
 
@@ -39,11 +40,7 @@ const { Content } = await render(post.entry);
       <h1 class="page-title">{post.entry.data.title}</h1>
       <div class="post-meta">
         <time datetime={post.dateStamp}>{post.dateStamp}</time>
-        {
-          post.entry.data.tags.length > 0 && (
-            <span>{post.entry.data.tags.join(", ")}</span>
-          )
-        }
+        <PostTags tags={post.entry.data.tags} />
       </div>
     </header>
     <div class="prose">

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,23 @@
+---
+import PostList from "../../components/PostList.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getTagGroups } from "../../lib/tags";
+
+export async function getStaticPaths() {
+  const groups = await getTagGroups();
+
+  return groups.map((group) => ({
+    params: { tag: group.slug },
+    props: { group },
+  }));
+}
+
+const { group } = Astro.props;
+---
+
+<BaseLayout title={group.name}>
+  <p class="tag-back"><a href="/tags">すべてのタグ</a></p>
+  <h1 class="page-title">{group.name}</h1>
+  <p class="post-meta">{group.posts.length} 件</p>
+  <PostList posts={group.posts} />
+</BaseLayout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,20 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getTagGroups } from "../../lib/tags";
+
+const groups = await getTagGroups();
+---
+
+<BaseLayout title="Tags">
+  <h1 class="page-title">Tags</h1>
+  <ul class="tag-index">
+    {
+      groups.map((group) => (
+        <li>
+          <a href={group.href}>{group.name}</a>
+          <span class="post-meta">{group.posts.length}</span>
+        </li>
+      ))
+    }
+  </ul>
+</BaseLayout>

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -87,6 +87,42 @@
   font-size: 0.9rem;
 }
 
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.post-list .post-tags a,
+.post-tags a {
+  color: var(--color-muted);
+  font-weight: 400;
+  text-decoration: none;
+}
+
+.post-list .post-tags a:hover,
+.post-tags a:hover {
+  color: var(--color-accent);
+}
+
+.tag-index {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.tag-index li {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-md);
+}
+
+.tag-back {
+  margin: 0 0 var(--space-sm);
+  font-size: 0.9rem;
+}
+
 .page-title {
   margin: 0 0 var(--space-lg);
   font-size: 1.75rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
タグで記事を辿れるようにし、WeeklyMemo の欠けていた画像を直し、検索エンジン向けの sitemap を追加しました。

## タグ

- `/tags` 一覧（WeeklyMemo 12 / 技術 42 / 日記 1）
- `/tags/weekly-memo`、`/tags/技術`、`/tags/日記`（Gatsby 当時と同じパス）
- 記事メタとナビからリンク

## WeeklyMemo 画像

Typora の `<img style="zoom:...">` は Astro が処理しないため、同じファイルを指す Markdown 画像に変換しました。

## Sitemap

- ビルドで `/sitemap-index.xml` と `/sitemap-0.xml` を出す
- 正規 URL だけ 49 件（トップ、Blog、About、タグ、記事 42 本）
- 旧スラッグの 301 ページは載せない
- `robots.txt` と `<link rel="sitemap">` から辿れる
- Gatsby 時代の `/sitemap/sitemap-index.xml` は新パスへ 301

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a25fe241-dc52-474e-b54e-54fe4f5906e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a25fe241-dc52-474e-b54e-54fe4f5906e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

